### PR TITLE
Adds a wayland feature flag to compile glfw with wayland support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,15 @@ cmake_dependent_option(GLFW_USE_OSMESA "Use OSMesa for offscreen context creatio
                        "UNIX" OFF)
 cmake_dependent_option(GLFW_USE_HYBRID_HPG "Force use of high-performance GPU on hybrid systems" OFF
                        "WIN32" OFF)
-cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
+
+if (${GLFW_BUILD_WAYLAND} STREQUAL "ON")
+    cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" ON
                        "UNIX;NOT APPLE" OFF)
+else()
+    cmake_dependent_option(GLFW_USE_WAYLAND "Use Wayland for window creation" OFF
+                       "UNIX;NOT APPLE" OFF)
+endif()
+
 cmake_dependent_option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON
                        "MSVC" OFF)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ path = "lib.rs"
 
 [build-dependencies]
 cmake = "0.1"
+
+[features]
+wayland = []

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,22 @@ extern crate cmake;
 use cmake::Config;
 
 fn main() {
-    let dst = Config::new(".")
-        .define("GLFW_BUILD_EXAMPLES", "OFF")
+    let mut cfg = Config::new(".");
+
+    cfg.define("GLFW_BUILD_EXAMPLES", "OFF")
         .define("GLFW_BUILD_TESTS", "OFF")
         .define("GLFW_BUILD_DOCS", "OFF")
-        .define("CMAKE_INSTALL_LIBDIR", "lib")
-        .build();
-    println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
+
+    let dst = if cfg!(feature = "wayland") {
+        cfg.define("GLFW_BUILD_WAYLAND", "ON").build()
+    } else {
+        cfg.define("GLFW_BUILD_WAYLAND", "OFF").build()
+    };
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib").display()
+    );
     println!("cargo:rustc-link-lib=dylib=glfw3");
 }


### PR DESCRIPTION
This PR adds support to specify a "wayland" feature flag to compile glfw with wayland support. This allows glfw-rs to compile with rust support as well, check https://github.com/PistonDevelopers/glfw-rs/pull/500