### PR TITLE
Update to GLFW 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ RelWithDebInfo
 GLFW.build
 GLFW.xcodeproj
 
+# RustRover clutter
+.idea
+
 # macOS clutter
 .DS_Store
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glfw-sys"
-version = "5.0.0+3.3.9"
+version = "5.0.0+3.4"
 authors = ["Camilla Berglund <elmindreda@elmindreda.org>"]
 description = "An Open Source, multi-platform library for creating windows with OpenGL contexts and receiving input and events"
 documentation = "http://www.glfw.org/documentation.html"

--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,13 @@ fn main() {
 
     if cfg!(feature = "wayland") {
         cfg.define("GLFW_BUILD_WAYLAND", "ON");
-        cfg.define("GLFW_BUILD_X11", "ON");
     } else {
         cfg.define("GLFW_BUILD_WAYLAND", "OFF");
+    }
+
+    if cfg!(any(target_os = "linux", target_os = "freebsd")) {
+        cfg.define("GLFW_BUILD_X11", "ON");
+    } else {
         cfg.define("GLFW_BUILD_X11", "OFF");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -9,15 +9,17 @@ fn main() {
         .define("GLFW_BUILD_DOCS", "OFF")
         .define("CMAKE_INSTALL_LIBDIR", "lib");
 
-    let dst = if cfg!(feature = "wayland") {
-        cfg.define("GLFW_USE_WAYLAND", "ON").build()
+    if cfg!(feature = "wayland") {
+        cfg.define("GLFW_BUILD_WAYLAND", "ON");
+        cfg.define("GLFW_BUILD_X11", "ON");
     } else {
-        cfg.define("GLFW_USE_WAYLAND", "OFF").build()
-    };
+        cfg.define("GLFW_BUILD_WAYLAND", "OFF");
+        cfg.define("GLFW_BUILD_X11", "OFF");
+    }
 
     println!(
         "cargo:rustc-link-search=native={}",
-        dst.join("lib").display()
+        cfg.build().join("lib").display()
     );
     println!("cargo:rustc-link-lib=dylib=glfw3");
 }


### PR DESCRIPTION
Updates the submodule to GLFW's 3.4 tag (or [commit 7b6aead](https://github.com/glfw/glfw/commit/7b6aead9fb88b3623e3b3725ebb42670cbe4c579)). Also adds an ignore field for RustRover IDE details.