### PR TITLE
Improve and fix the build system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["all"]
 all = ["x11", "wayland", "native-handles", "native-gl", "native-egl", "vulkan"]
 bindgen = ["dep:bindgen"]
 # build from source, instead of using prebuilt libraries.
-src-build = ["dep:cmake"]
+src-build = []
 prebuilt-libs = []
 
 static-link = [] # static link (if on linux, src-build must also be enabled)
@@ -35,7 +35,7 @@ osmesa = []
 
 [build-dependencies]
 bindgen = { version = "0.71", optional = true }
-cmake = { version = "0.1", optional = true }
+cmake = "0.1"
 pkg-config = "0.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library has two main purposes:
 
 
 For normal applications, you only need to care about 2 features:
-1. `src-build` - if you want to build from source. adds around 10 seconds of build time.
+1. `src-build` - if you want to build from source. adds around 10 seconds of build time. It will also build from source if pkg-config fails (then `static-link` also applies).
 2. `static-link` - if you want to link statically. On linux, this requires `src-build` too, so prefer dynamic linking during development for faster compile times. 
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library has two main purposes:
 
 
 For normal applications, you only need to care about 2 features:
-1. `src-build` - if you want to build from source. adds around 10 seconds of build time. It will also build from source if pkg-config fails (then `static-link` also applies).
+1. `src-build` - if you want to build from source. adds around 10 seconds of build time. It will also build from source if pkg-config fails (regardless of this feature).
 2. `static-link` - if you want to link statically. On linux, this requires `src-build` too, so prefer dynamic linking during development for faster compile times. 
 
 ### Features

--- a/build.rs
+++ b/build.rs
@@ -55,8 +55,9 @@ fn main() {
                 println!("pkg-config found glfw library {lib:#?}");
                 pkgconfig_build = true;
             },
-            Err(e) => {
+            Err(_) => {
                 // on failure try to build
+                println!("cargo::warning=Failed to link against system GLFW. GLFW will be built instead.");
                 pkgconfig_build = false;
                 build_from_src(features, &out_dir);
             }

--- a/build.rs
+++ b/build.rs
@@ -256,9 +256,9 @@ fn build_from_src(features: Features, _out_dir: &str) {
         }
     }
     if features.static_link {
-        config.define("GLFW_LIBRARY_TYPE", "STATIC");
+        config.define("BUILD_SHARED_LIBS", "OFF");
     } else {
-        config.define("GLFW_LIBRARY_TYPE", "SHARED");
+        config.define("BUILD_SHARED_LIBS", "ON");
     }
     let dst_dir = config.build();
     println!(

--- a/build.rs
+++ b/build.rs
@@ -64,7 +64,7 @@ fn main() {
         } else {
             match features.os {
                 TargetOs::Win => println!("cargo:rustc-link-lib=dylib=glfw3dll"),
-                _ => println!("cargo:rustc-link-lib=dylib=glfw"),
+                _ => println!("cargo:rustc-link-lib=dylib=glfw3"),
             }
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,7 @@ fn main() {
             .probe("glfw3")
         {
             Ok(lib) => println!("pkg-config found glfw library {lib:#?}"),
-            Err(e) => panic!("pkg-config failed to find glfw library: {e}"),
+            Err(e) => build_from_src(features, &out_dir),
         }
     }
 
@@ -254,7 +254,7 @@ fn build_from_src(features: Features, _out_dir: &str) {
     let dst_dir = config.build();
     println!(
         "cargo:rustc-link-search=native={}",
-        dst_dir.join("lib").display()
+        dst_dir.join("lib64").display()
     );
     if !features.static_link && features.os == TargetOs::Win {
         println!(

--- a/build.rs
+++ b/build.rs
@@ -226,7 +226,6 @@ impl Default for Features {
 /// builds from source using cmake.
 /// The sources are included with this crate.
 /// feature-gated to make cmake crate optional.
-#[cfg(feature = "src-build")]
 fn build_from_src(features: Features, _out_dir: &str) {
     let mut config = cmake::Config::new("./glfw");
     config

--- a/build.rs
+++ b/build.rs
@@ -263,7 +263,7 @@ fn build_from_src(features: Features, _out_dir: &str) {
     let dst_dir = config.build();
     println!(
         "cargo:rustc-link-search=native={}",
-        dst_dir.join("lib64").display()
+        dst_dir.join("lib").display()
     );
     if !features.static_link && features.os == TargetOs::Win {
         println!(

--- a/build.rs
+++ b/build.rs
@@ -40,12 +40,12 @@ fn main() {
         pkgconfig_build = false;
         download_libs(features, &out_dir);
     }
-    else if features.src_build && features.static_link {  // compile and statically link.
+    else if features.src_build {  // build from source.
         pkgconfig_build = false;
         #[cfg(feature = "src-build")]
         build_from_src(features, &out_dir);
     }
-    else {  // try to use pkg-config first and build on failure if enabled.
+    else {  // try to use pkg-config first and build from source on failure.
         // emits linker flags by default.
         match pkg_config::Config::new()
             .statik(features.static_link)
@@ -57,15 +57,9 @@ fn main() {
                 pkgconfig_build = true;
             },
             Err(e) => {
-                // on failure try to build if enabled
+                // on failure try to build
                 pkgconfig_build = false;
-                if features.src_build {
-                    #[cfg(feature = "src-build")]
-                    build_from_src(features, &out_dir);
-                }
-                else {
-                    panic!("pkg-config failed to find glfw library: {e}");
-                }
+                build_from_src(features, &out_dir);
             }
         }
     }
@@ -240,7 +234,6 @@ impl Default for Features {
 /// builds from source using cmake.
 /// The sources are included with this crate.
 /// feature-gated to make cmake crate optional.
-#[cfg(feature = "src-build")]
 fn build_from_src(features: Features, _out_dir: &str) {
     let mut config = cmake::Config::new("./glfw");
     config

--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,6 @@ fn main() {
     }
     else if features.src_build {  // build from source.
         pkgconfig_build = false;
-        #[cfg(feature = "src-build")]
         build_from_src(features, &out_dir);
     }
     else {  // try to use pkg-config first and build from source on failure.

--- a/build.rs
+++ b/build.rs
@@ -239,7 +239,9 @@ fn build_from_src(features: Features, _out_dir: &str) {
     config
         .define("GLFW_BUILD_EXAMPLES", "OFF")
         .define("GLFW_BUILD_TESTS", "OFF")
-        .define("GLFW_BUILD_DOCS", "OFF");
+        .define("GLFW_BUILD_DOCS", "OFF")
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
+
     // x11/wayland work on all sorts of OSes.
     if features.os == TargetOs::Linux || features.os == TargetOs::Others {
         if features.wayland {

--- a/build.rs
+++ b/build.rs
@@ -72,7 +72,7 @@ fn main() {
         } else {
             match features.os {
                 TargetOs::Win => println!("cargo:rustc-link-lib=dylib=glfw3dll"),
-                _ => println!("cargo:rustc-link-lib=dylib=glfw3"),
+                _ => println!("cargo:rustc-link-lib=dylib=glfw"),
             }
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -36,12 +36,16 @@ fn main() {
     }
 
     let pkgconfig_build;
-    if features.prebuilt_libs {
+    if features.prebuilt_libs {  // prebuilt libs.
         pkgconfig_build = false;
         download_libs(features, &out_dir);
     }
-    else {
-        // try to use pkg-config first
+    else if features.src_build && features.static_link {  // compile and statically link.
+        pkgconfig_build = false;
+        #[cfg(feature = "src-build")]
+        build_from_src(features, &out_dir);
+    }
+    else {  // try to use pkg-config first and build on failure if enabled.
         // emits linker flags by default.
         match pkg_config::Config::new()
             .statik(features.static_link)
@@ -236,6 +240,7 @@ impl Default for Features {
 /// builds from source using cmake.
 /// The sources are included with this crate.
 /// feature-gated to make cmake crate optional.
+#[cfg(feature = "src-build")]
 fn build_from_src(features: Features, _out_dir: &str) {
     let mut config = cmake::Config::new("./glfw");
     config

--- a/build.rs
+++ b/build.rs
@@ -240,7 +240,7 @@ fn build_from_src(features: Features, _out_dir: &str) {
         .define("GLFW_BUILD_EXAMPLES", "OFF")
         .define("GLFW_BUILD_TESTS", "OFF")
         .define("GLFW_BUILD_DOCS", "OFF")
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
+        .define("CMAKE_INSTALL_LIBDIR", "lib64");
 
     // x11/wayland work on all sorts of OSes.
     if features.os == TargetOs::Linux || features.os == TargetOs::Others {
@@ -256,14 +256,14 @@ fn build_from_src(features: Features, _out_dir: &str) {
         }
     }
     if features.static_link {
-        config.define("BUILD_SHARED_LIBS", "OFF");
+        config.define("GLFW_LIBRARY_TYPE", "STATIC");
     } else {
-        config.define("BUILD_SHARED_LIBS", "ON");
+        config.define("GLFW_LIBRARY_TYPE", "SHARED");
     }
     let dst_dir = config.build();
     println!(
         "cargo:rustc-link-search=native={}",
-        dst_dir.join("lib").display()
+        dst_dir.join("lib64").display()
     );
     if !features.static_link && features.os == TargetOs::Win {
         println!(

--- a/build.rs
+++ b/build.rs
@@ -240,7 +240,7 @@ fn build_from_src(features: Features, _out_dir: &str) {
         .define("GLFW_BUILD_EXAMPLES", "OFF")
         .define("GLFW_BUILD_TESTS", "OFF")
         .define("GLFW_BUILD_DOCS", "OFF")
-        .define("CMAKE_INSTALL_LIBDIR", "lib64");
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
 
     // x11/wayland work on all sorts of OSes.
     if features.os == TargetOs::Linux || features.os == TargetOs::Others {
@@ -263,7 +263,7 @@ fn build_from_src(features: Features, _out_dir: &str) {
     let dst_dir = config.build();
     println!(
         "cargo:rustc-link-search=native={}",
-        dst_dir.join("lib64").display()
+        dst_dir.join("lib").display()
     );
     if !features.static_link && features.os == TargetOs::Win {
         println!(


### PR DESCRIPTION
Makes improvements to the build script:
- if `pkg-config` fails, building will happen regardless of the `src-build` feature;
- fixes the issue with linking on some Linux distros and thus closes #36;