### PR TITLE
Define `DEP_GLFW_THIRD_PARTY` in build script.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -229,6 +229,8 @@ impl Default for Features {
 #[cfg(feature = "src-build")]
 fn build_from_src(features: Features, _out_dir: &str) {
     let mut config = cmake::Config::new("./glfw");
+    let lib_dir = std::env::current_dir().unwrap().join("glfw");
+    println!("cargo:THIRD_PARTY={}", lib_dir.display());
     config
         .define("GLFW_BUILD_EXAMPLES", "OFF")
         .define("GLFW_BUILD_TESTS", "OFF")
@@ -436,6 +438,7 @@ fn download_libs(features: Features, out_dir: &str) {
     );
     println!("extracted glfw library from zip and stored it in {out_dir:?}");
     let lib_dir = std::path::Path::new(out_dir).join(zip_name);
+    println!("cargo:THIRD_PARTY={}", lib_dir.display());
     match features.os {
         TargetOs::Win => {
             println!(


### PR DESCRIPTION
It is somewhat idiomatic that a `*-sys` crate that includes a copy of the source of its dependency to define an environment variable to make that source available for dependencies.

This is important if the dependencies also contains C code that needs the original header file. They shouldn't include its own copy because it could be different and create incompatibilities.

With this commit, if the included source or precompiled binary are used, dependencies can read the `DEP_GLFW_THIRD_PARTY` environment variable to find the necessary headers.