### PR TITLE
Default to static linking and add mingw support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ bindgen = ["dep:bindgen"]
 src-build = []
 prebuilt-libs = []
 
-static-link = [] # static link (if on linux, src-build must also be enabled)
+dynamic-link = [] # explicitly opt into dynamic linking
 vulkan = []
 wayland = []
 x11 = []
 native-handles = []
 native-gl = []
-native-egl = [] 
-osmesa = [] 
+native-egl = []
+osmesa = []
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For normal applications, you only need to care about 2 features:
 - `dynamic-link` - dynamically link glfw (creates runtime dependency). If disabled, we will statically link glfw
 
 We try to build glfw in this order:
-- `src-build` - If enabled, build glfw from source (sources are included with crate). Ensure `cmake` is installed and any other required dependencies.
+- `src-build` - If enabled, build glfw from source (sources are included with crate). Ensure `cmake` is installed and any other required dependencies. **This takes priority over `prebuilt-libs` if both are enabled.**
 - `prebuilt-libs` (only for windows/macos. ignored on other platforms) - If enabled, we download and link pre-built glfw libs from <https://github.com/glfw/glfw/releases/>.
 
 > NOTE: We use curl + tar (unzip on macos) to download and extract pre-built libs. mac/win10+ will have these by default.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library has two main purposes:
 
 For normal applications, you only need to care about 2 features:
 1. `src-build` - if you want to build from source. adds around 10 seconds of build time. It will also build from source if pkg-config fails (regardless of this feature).
-2. `static-link` - if you want to link statically. On linux, this requires `src-build` too, so prefer dynamic linking during development for faster compile times. 
+2. `dynamic-link` - if you want to link dynamically to GLFW. Dynamic linking can provide faster compile times during development.
 
 ### Features
 
@@ -18,7 +18,7 @@ For normal applications, you only need to care about 2 features:
 
 > NOTE: For emscripten, none of these features apply. We just pass the necessary flags like `-sUSE_GLFW=3` to linker and simply let emscripten take care of things.
 
-- `static-link` - statically link glfw. If disabled, we will dynamically link glfw.
+- `dynamic-link` - dynamically link glfw (creates runtime dependency). If disabled, we will statically link glfw
 
 We try to build glfw in this order:
 - `src-build` - If enabled, build glfw from source (sources are included with crate). Ensure `cmake` is installed and any other required dependencies.
@@ -26,7 +26,7 @@ We try to build glfw in this order:
 
 > NOTE: We use curl + tar (unzip on macos) to download and extract pre-built libs. mac/win10+ will have these by default.
 
-Finally, if neither `src-build` nor `prebuilt-libs` feature is enabled, we will try to use `pkg-config` to find and link to system glfw libs.
+Finally, if neither `src-build` nor `prebuilt-libs` feature is enabled, we will try to use `pkg-config` to find and link to system glfw libs. By default, this will attempt static linking unless the `dynamic-link` feature is enabled.
 
 #### Platform Backends (non-mac and non-windows only)
 * `x11` and `wayland` - enables support for x11/wayland. Enable both and you can choose which one to use during initialization. `x11/wayland` are ignored on windows/macos platforms.
@@ -39,7 +39,7 @@ Finally, if neither `src-build` nor `prebuilt-libs` feature is enabled, we will 
 These features expose native "HWND"/"NSWindow"/"X11Connection" etc.. handles.
 Unless you are using `wgpu`-like libs that need raw-window-handles, these features can be ignored.
 - `native-handles` - enable APIs to get platform specific window handles or display connections or monitor ids. useful for raw-window-handle support.
-- `native-gl` - enable APIs for getting platform specific gl contexts (`wgl`, `egl`, `glx`, `nsgl` etc..). Most users should ignore this. 
+- `native-gl` - enable APIs for getting platform specific gl contexts (`wgl`, `egl`, `glx`, `nsgl` etc..). Most users should ignore this.
 - `native-egl` - enable egl API even for x11 builds, if you plan to use `egl` contexts with x11 windows. Most users should ignore this.
 
 #### Miscellaneous
@@ -63,7 +63,7 @@ These features will influence the bindings generated.
 * `vulkan` - includes vulkan header for vk related types (eg: `vkInstance`).
 
 ### Release Check List
-* When updating glfw version, make sure to checkout the submodule and commit it. 
+* When updating glfw version, make sure to checkout the submodule and commit it.
 * When updating glfw version, don't forget to change the url link in build.rs to download the pre-built libs of the correct version.
 * When updating glfw version, don't forget to update the pkg-config `atleast_version` argument.
 * Check that the bindings generated are the same on all platforms by checking the CI logs for the `gen_bindings.sh` step.

--- a/build.rs
+++ b/build.rs
@@ -36,15 +36,13 @@ fn main() {
     }
 
     let pkgconfig_build;
-    if features.prebuilt_libs {  // prebuilt libs.
-        pkgconfig_build = false;
-        download_libs(features, &out_dir);
-    }
-    else if features.src_build {  // build from source.
+    if features.src_build {
         pkgconfig_build = false;
         build_from_src(features, &out_dir);
-    }
-    else {  // try to use pkg-config first and build from source on failure.
+    } else if features.prebuilt_libs {
+        pkgconfig_build = false;
+        download_libs(features, &out_dir);
+    } else {  // try to use pkg-config first and build from source on failure.
         // emits linker flags by default.
         match pkg_config::Config::new()
             .statik(!features.dynamic_link)
@@ -226,8 +224,10 @@ impl Default for Features {
             gl: cfg!(feature = "native-gl"),
             src_build: cfg!(feature = "src-build"),
             // this feature only works on windows and mac
+            // Don't enable prebuilt_libs if src_build is explicitly requested
             prebuilt_libs: cfg!(feature = "prebuilt-libs")
-                && (os == TargetOs::Win || os == TargetOs::Mac),
+                && (os == TargetOs::Win || os == TargetOs::Mac)
+                && !cfg!(feature = "src-build"),
         }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -450,10 +450,18 @@ fn download_libs(features: Features, out_dir: &str) {
     println!("cargo:THIRD_PARTY={}", lib_dir.display());
     match features.os {
         TargetOs::Win => {
-            println!(
-                "cargo:rustc-link-search=native={}",
-                lib_dir.join("lib-vc2022").display()
-            );
+            // Default to mingw libs for gnu targets and vc2022 for msvc
+            if std::env::var("CARGO_CFG_TARGET_ENV").unwrap() == "gnu" {
+                println!(
+                    "cargo:rustc-link-search=native={}",
+                    lib_dir.join("lib-mingw-w64").display()
+                );
+            } else {
+                println!(
+                    "cargo:rustc-link-search=native={}",
+                    lib_dir.join("lib-vc2022").display()
+                );
+            }
         }
         TargetOs::Mac => {
             let lib_dir = lib_dir.join("lib-universal");


### PR DESCRIPTION
This PR fixes a couple of issues I ran into while cross-compiling for Windows. When using mingw or cross-compiling (with the `prebuilt-libs` flag), it now properly uses the mingw-w64 libraries instead of defaulting to the vc2022 ones which don't work with GNU toolchains.

The main change though is switching to static linking by default across all build configurations, with a new `dynamic-link` feature if you specifically want dynamic linking. Before this, the static-link feature was confusing and `src-build` would unexpectedly create executables that relied on `glfw3.dll` at runtime. Now it just statically links everything by default unless you explicitly ask for dynamic linking, which makes way more sense and fixes the weird dependency issues I was hitting.